### PR TITLE
Fix spelling of “implied” in antipattern title

### DIFF
--- a/content/antipatterns/missing_implied_return_type.mdx
+++ b/content/antipatterns/missing_implied_return_type.mdx
@@ -1,5 +1,5 @@
 ---
-title: Missing impled return type
+title: Missing implied return type
 ---
 # Missing implied return type
 


### PR DESCRIPTION
The misspelling as seen in the yellow-filled box on the [current page](https://www.linguistic-antipatterns.com/):

<img width="810" alt="misspelling “impled” on page" src="https://user-images.githubusercontent.com/79168/184290289-e83d52c3-cba6-42d5-99e7-de13120c3960.png">
